### PR TITLE
Filter faulty nameserver

### DIFF
--- a/nxbender/resolvconf.py
+++ b/nxbender/resolvconf.py
@@ -24,7 +24,8 @@ class ResolvConf(object):
         # nameserver lines
         for dns in ['dns1', 'dns2', 'dns3']:
             try:
-                resolv_conf_lines.append(f'nameserver {srv_options[dns]}')
+                if srv_options[dns] != "0.0.0.0":
+                    resolv_conf_lines.append(f'nameserver {srv_options[dns]}')
             except KeyError as err:
                 # ignore these, because the number of DNS servers returned will vary
                 pass


### PR DESCRIPTION
I encountered a server that sends `0.0.0.0` as the second nameserver. `resolvconf` just ignores it, but `systemd-resolved` (via the `resolvconf` compatibility binary) fails.
This PR adds a filter for this address so it won't be passed to `resolvconf`.